### PR TITLE
make test compare precice configs

### DIFF
--- a/tests/generation-tests/test_generation.py
+++ b/tests/generation-tests/test_generation.py
@@ -367,7 +367,7 @@ def test_generate(capsys, example_nr):
 
         # Format precice config
         print("Formatting precice config...")
-        fileGenerator.format_precice_config(output_path)
+        fileGenerator.format_precice_config()
 
         captured = capsys.readouterr()
         assert "error" not in captured.out.lower() and "error" not in captured.err.lower(), \


### PR DESCRIPTION
This will compare the generated precice config with the one from the examples.
It is using a custom xml reader/tree as the xml etree one has problems with the namespaces.

# For some reason the new formatter breaks the test