### PR TITLE
fix error participants in couplingscheme hopefully

### DIFF
--- a/controller_utils/precice_struct/PS_CouplingScheme.py
+++ b/controller_utils/precice_struct/PS_CouplingScheme.py
@@ -58,9 +58,9 @@ class PS_CouplingScheme(object):
             for participant_name in config.solvers:
                 participant = config.solvers[participant_name]
                 if participant.name == control_participant_name:
-                    i = etree.SubElement(coupling_scheme, "participants", name=participant_name, control="yes")
+                    i = etree.SubElement(coupling_scheme, "participant", name=participant_name, control="yes")
                 else:
-                    i = etree.SubElement(coupling_scheme, "participants", name=participant_name)
+                    i = etree.SubElement(coupling_scheme, "participant", name=participant_name)
                     pass
                 pass
             pass

--- a/generation_utils/format_precice_config.py
+++ b/generation_utils/format_precice_config.py
@@ -299,7 +299,7 @@ class PrettyPrinter():
                 # Print initial elements
                 initial_elements = [
                     elem for elem in other_elements 
-                    if str(elem.tag) in ['participants', 'max-time', 'time-window-size']
+                    if str(elem.tag) in ['participants', 'participant', 'max-time', 'time-window-size']
                 ]
                 for child in initial_elements:
                     self.printElement(child, level + 1)


### PR DESCRIPTION
> Thx a lot guys, we somehow missed that there is `participant`**s** `first=... second= ...` and `participant name=... (control=yes)`. Lets just say that was a typo 😉 Now the config-checker runs and returns warnings/errors and does not stop executing on one example.

https://github.com/precice-forschungsprojekt/config-checker/issues/70