### PR TITLE
Explicitly always generate receive mesh on the participant who is specifying a mapping

### DIFF
--- a/controller_utils/precice_struct/PS_PreCICEConfig.py
+++ b/controller_utils/precice_struct/PS_PreCICEConfig.py
@@ -292,7 +292,7 @@ class PS_PreCICEConfig(object):
                             type_of_the_mapping_read[other_solvers_name] = q.mapping_string
                             # within one participant put the "use-mesh" only once there
                             if solvers_mesh_name != q.source_mesh_name and \
-                               q.source_mesh_name not in used_meshes:
+                                            q.source_mesh_name not in used_meshes:
                                 solver_mesh_tag = etree.SubElement(solver_tag,
                                                                    "receive-mesh", name=q.source_mesh_name,
                                                                    from___=q.source_solver.name)


### PR DESCRIPTION
Should fix #142 
The topology from the issue now returns:
```xml

<?xml version="1.0" encoding="UTF-8"?>

<precice-configuration>
    <data:vector name="Force"/>

    <mesh name="Generator-Mesh" dimensions="3">
        <use-data name="Force"/>
    </mesh>

    <mesh name="Propagator-Mesh" dimensions="3">
        <use-data name="Force"/>
    </mesh>

    <participant name="Generator">
        <provide-mesh name="Generator-Mesh"/>
        <receive-mesh name="Propagator-Mesh" from="Propagator"/>

        <write-data name="Force" mesh="Generator-Mesh"/>

        <mapping:nearest-neighbor
            direction="write"
            from="Generator-Mesh"
            to="Propagator-Mesh"
            constraint="conservative"
         />
    </participant>

    <participant name="Propagator">
        <provide-mesh name="Propagator-Mesh"/>

        <read-data name="Force" mesh="Propagator-Mesh"/>
    </participant>

    <m2n:sockets acceptor="Generator" connector="Propagator" exchange-directory=".."/>

    <coupling-scheme:serial-explicit>
        <participants first="Generator" second="Propagator"/>
        <max-time value="0.3"/>
        <time-window-size value="0.01"/>

        <exchange data="Force" mesh="Propagator-Mesh" from="Generator" to="Propagator"/>
    </coupling-scheme:serial-explicit>
</precice-configuration>

```